### PR TITLE
make the API fully const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,12 +101,12 @@
 mod properties;
 mod state;
 
-use core::iter::FusedIterator;
+use core::{iter::FusedIterator, marker::PhantomData};
 
 pub use properties::*;
 
 use state::State;
-use u8char::u8char;
+pub use u8char::u8char;
 
 /// A finite state machine for detecting grapheme cluster boundaries.
 ///
@@ -213,42 +213,16 @@ impl GraphemeMachine {
     /// end of the string is reached, so it's okay to provide streaming
     /// input in a series of [`str`] chunks even if there are grapheme
     /// clusters straddling across the buffer boundaries.
-    pub const fn next_u8chars_from_str<'a>(
-        &'a mut self,
-        s: &'a str,
-    ) -> impl Iterator<Item = (ClusterAction, u8char)> + FusedIterator + 'a {
-        struct Iter<'a> {
-            machine: &'a mut GraphemeMachine,
-            remain: &'a str,
-        }
-        impl<'a> Iterator for Iter<'a> {
-            type Item = (ClusterAction, u8char);
-            fn next(&mut self) -> Option<Self::Item> {
-                let (next, rest) = u8char::from_string_prefix(self.remain);
-                let Some(next) = next else {
-                    return None;
-                };
-                let action = self.machine.next_u8char(next);
-                self.remain = rest;
-                Some((action, next))
-            }
-        }
-        impl<'a> FusedIterator for Iter<'a> {}
-        Iter {
-            machine: self,
-            remain: s,
-        }
+    pub const fn next_u8chars_from_str<'a>(&'a mut self, s: &'a str) -> IterChar<'a, u8char> {
+        IterChar::<u8char> { machine: self, remain: s, _marker: PhantomData }
     }
 
     /// Behaves the same as [`Self::next_u8chars_from_str`] except that it
     /// also converts the characters to [`char`], for more convenient use
     /// by callers who are interacting with something that only supports
     /// Rust's standard character representation.
-    pub fn next_chars_from_str<'a>(
-        &'a mut self,
-        s: &'a str,
-    ) -> impl Iterator<Item = (ClusterAction, char)> + FusedIterator + 'a {
-        self.next_u8chars_from_str(s).map(|(a, c)| (a, c.to_char()))
+    pub const fn next_chars_from_str<'a>(&'a mut self, s: &'a str) -> IterChar<'a, char> {
+        IterChar::<char> { machine: self, remain: s, _marker: PhantomData }
     }
 
     /// Tells the state machine that the input stream has ended.
@@ -285,6 +259,48 @@ pub enum ClusterAction {
     /// that initially consists only of the new character.
     Split,
 }
+
+
+/// An iterator over characters of type either u8char or char.
+#[doc(hidden)]
+pub struct IterChar<'a, T> {
+    machine: &'a mut GraphemeMachine,
+    remain: &'a str,
+    _marker: PhantomData<T>,
+}
+impl<'a> IterChar<'a, u8char> {
+    pub const fn next(&mut self) -> Option<(ClusterAction, u8char)> {
+        let (next, rest) = u8char::from_string_prefix(self.remain);
+        let Some(next) = next else { return None; };
+        let action = self.machine.next_u8char(next);
+        self.remain = rest;
+        Some((action, next))
+    }
+}
+impl<'a> Iterator for IterChar<'a, u8char> {
+    type Item = (ClusterAction, u8char);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+}
+impl<'a> FusedIterator for IterChar<'a, u8char> {}
+
+impl<'a> IterChar<'a, char> {
+    pub const fn next(&mut self) -> Option<(ClusterAction, char)> {
+        let (next, rest) = u8char::from_string_prefix(self.remain);
+        let Some(next) = next else { return None; };
+        let action = self.machine.next_u8char(next);
+        self.remain = rest;
+        Some((action, next.to_char()))
+    }
+}
+impl<'a> Iterator for IterChar<'a, char> {
+    type Item = (ClusterAction, char);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+}
+impl<'a> FusedIterator for IterChar<'a, char> {}
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub struct GraphemeMachine {
 impl GraphemeMachine {
     /// Constructs a new [`GraphemeMachine`] in an initial "start of input"
     /// state.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         GraphemeMachine {
             state: State::Base,
             prev: None,
@@ -158,7 +158,7 @@ impl GraphemeMachine {
     /// At the start of input when there is no previous character the action
     /// is always [`ClusterAction::Split`], because there is no current
     /// grapheme cluster to possibly extend.
-    pub fn next_char_properties(&mut self, next: CharProperties) -> ClusterAction {
+    pub const fn next_char_properties(&mut self, next: CharProperties) -> ClusterAction {
         let (boundary, next_state) = self.state.transition(self.prev, next);
         self.state = next_state;
         self.prev = Some(next);
@@ -174,7 +174,7 @@ impl GraphemeMachine {
     ///
     /// Refer to the documentation of that function for information on the
     /// meaning of the result.
-    pub fn next_u8char(&mut self, c: u8char) -> ClusterAction {
+    pub const fn next_u8char(&mut self, c: u8char) -> ClusterAction {
         let props = CharProperties::for_u8char(c);
         self.next_char_properties(props)
     }
@@ -190,7 +190,7 @@ impl GraphemeMachine {
     /// first convert the given character to the `u8char` representation. If
     /// you already have the character in `u8char` form then you can avoid
     /// unnecessary conversions by calling [`Self::next_u8char`] instead.
-    pub fn next_char(&mut self, c: char) -> ClusterAction {
+    pub const fn next_char(&mut self, c: char) -> ClusterAction {
         let props = CharProperties::for_char(c);
         self.next_char_properties(props)
     }
@@ -213,7 +213,7 @@ impl GraphemeMachine {
     /// end of the string is reached, so it's okay to provide streaming
     /// input in a series of [`str`] chunks even if there are grapheme
     /// clusters straddling across the buffer boundaries.
-    pub fn next_u8chars_from_str<'a>(
+    pub const fn next_u8chars_from_str<'a>(
         &'a mut self,
         s: &'a str,
     ) -> impl Iterator<Item = (ClusterAction, u8char)> + FusedIterator + 'a {
@@ -269,7 +269,7 @@ impl GraphemeMachine {
     /// For consistency with the other machine-advancing methods this returns
     /// an action to take, but at the end of input the action is always
     /// [`ClusterAction::Split`] to mark the end of the final grapheme cluster.
-    pub fn end_of_input(&mut self) -> ClusterAction {
+    pub const fn end_of_input(&mut self) -> ClusterAction {
         self.state = State::Base;
         self.prev = None;
         ClusterAction::Split

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ pub use u8char::u8char;
 /// byte. Each newly-submitted character therefore updates the record of
 /// the most recent character and advances the internal state machine based
 /// on the new character.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GraphemeMachine {
     state: State,
     prev: Option<CharProperties>,
@@ -256,10 +256,20 @@ impl GraphemeMachine {
         self.prev = None;
         ClusterAction::Split
     }
+
+    /// Const-compatible `Eq`.
+    pub const fn eq(self, other: Self) -> bool {
+        self.state.eq(other.state)
+            && match (self.prev, other.prev) {
+                (Some(prev), Some(other_prev)) => prev.eq(other_prev),
+                (None, None) => true,
+                _ => false,
+            }
+    }
 }
 
 /// What to do with a new character after presenting it to a [GraphemeMachine].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ClusterAction {
     /// Treat the new character as an extension of the current grapheme cluster.
     Continue,
@@ -267,9 +277,19 @@ pub enum ClusterAction {
     /// that initially consists only of the new character.
     Split,
 }
+impl ClusterAction {
+    /// Const-compatible `Eq`.
+    pub const fn eq(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Continue, Self::Continue) | (Self::Split, Self::Split)
+        )
+    }
+}
 
 /// An iterator over characters of type either u8char or char.
 #[doc(hidden)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct IterChar<'a, T> {
     machine: &'a mut GraphemeMachine,
     remain: &'a str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,11 @@ impl GraphemeMachine {
     /// input in a series of [`str`] chunks even if there are grapheme
     /// clusters straddling across the buffer boundaries.
     pub const fn next_u8chars_from_str<'a>(&'a mut self, s: &'a str) -> IterChar<'a, u8char> {
-        IterChar::<u8char> { machine: self, remain: s, _marker: PhantomData }
+        IterChar::<u8char> {
+            machine: self,
+            remain: s,
+            _marker: PhantomData,
+        }
     }
 
     /// Behaves the same as [`Self::next_u8chars_from_str`] except that it
@@ -222,7 +226,11 @@ impl GraphemeMachine {
     /// by callers who are interacting with something that only supports
     /// Rust's standard character representation.
     pub const fn next_chars_from_str<'a>(&'a mut self, s: &'a str) -> IterChar<'a, char> {
-        IterChar::<char> { machine: self, remain: s, _marker: PhantomData }
+        IterChar::<char> {
+            machine: self,
+            remain: s,
+            _marker: PhantomData,
+        }
     }
 
     /// Tells the state machine that the input stream has ended.
@@ -260,7 +268,6 @@ pub enum ClusterAction {
     Split,
 }
 
-
 /// An iterator over characters of type either u8char or char.
 #[doc(hidden)]
 pub struct IterChar<'a, T> {
@@ -271,7 +278,9 @@ pub struct IterChar<'a, T> {
 impl<'a> IterChar<'a, u8char> {
     pub const fn next(&mut self) -> Option<(ClusterAction, u8char)> {
         let (next, rest) = u8char::from_string_prefix(self.remain);
-        let Some(next) = next else { return None; };
+        let Some(next) = next else {
+            return None;
+        };
         let action = self.machine.next_u8char(next);
         self.remain = rest;
         Some((action, next))
@@ -288,7 +297,9 @@ impl<'a> FusedIterator for IterChar<'a, u8char> {}
 impl<'a> IterChar<'a, char> {
     pub const fn next(&mut self) -> Option<(ClusterAction, char)> {
         let (next, rest) = u8char::from_string_prefix(self.remain);
-        let Some(next) = next else { return None; };
+        let Some(next) = next else {
+            return None;
+        };
         let action = self.machine.next_u8char(next);
         self.remain = rest;
         Some((action, next.to_char()))

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -14,7 +14,7 @@ mod table;
 /// they are an implementation detail subject to change in future versions of
 /// this library.
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GCBProperty {
     /// Represents that none of the grapheme cluster break property values
     /// apply to a particular character at all.
@@ -34,6 +34,29 @@ pub enum GCBProperty {
     V = 0x0d,
     ZWJ = 0x0e,
 }
+impl GCBProperty {
+    /// Const-compatible `Eq`.
+    pub const fn eq(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::None, Self::None)
+                | (Self::CR, Self::CR)
+                | (Self::Control, Self::Control)
+                | (Self::Extend, Self::Extend)
+                | (Self::ExtendedPictographic, Self::ExtendedPictographic)
+                | (Self::L, Self::L)
+                | (Self::LF, Self::LF)
+                | (Self::LV, Self::LV)
+                | (Self::LVT, Self::LVT)
+                | (Self::Prepend, Self::Prepend)
+                | (Self::RegionalIndicator, Self::RegionalIndicator)
+                | (Self::SpacingMark, Self::SpacingMark)
+                | (Self::T, Self::T)
+                | (Self::V, Self::V)
+                | (Self::ZWJ, Self::ZWJ)
+        )
+    }
+}
 
 /// Enumeration of **Indic_Conjunct_Break** property values, as defined in
 /// DerivedCoreProperties.txt based on
@@ -46,7 +69,7 @@ pub enum GCBProperty {
 /// they are an implementation detail subject to change in future versions of
 /// this library.
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum InCBProperty {
     /// Represents that none of the Indic_Conjunct_Break property values
     /// apply to a particular character at all.
@@ -54,6 +77,18 @@ pub enum InCBProperty {
     Consonant = 0x10,
     Extend = 0x20,
     Linker = 0x30,
+}
+impl InCBProperty {
+    /// Const-compatible `Eq`.
+    pub const fn eq(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::None, Self::None)
+                | (Self::Consonant, Self::Consonant)
+                | (Self::Extend, Self::Extend)
+                | (Self::Linker, Self::Linker)
+        )
+    }
 }
 
 /// Represents selections from the two derived Unicode character properties
@@ -66,7 +101,7 @@ pub enum InCBProperty {
 /// are defined in terms of both sets of property values, and so this type
 /// serves as a compact tuple of one selection from each.
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CharProperties {
     /// Bitfield representation of the property tuple. The enum values
     /// of [`GCBProperty`] and [`InCBProperty`] are defined such that one
@@ -136,6 +171,11 @@ impl CharProperties {
             self.gcb_property(),
             GCBProperty::LF | GCBProperty::CR | GCBProperty::Control,
         )
+    }
+
+    /// Const-compatible `Eq`.
+    pub const fn eq(self, other: Self) -> bool {
+        self.raw == other.raw
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -56,7 +56,11 @@ impl State {
     /// Correct use requires that the `prev` of one call equals the `next`
     /// of the previous call that generated the new state. If that is not
     /// upheld then the results are unspecified.
-    pub fn transition(self, prev: Option<CharProperties>, next: CharProperties) -> (bool, State) {
+    pub const fn transition(
+        self,
+        prev: Option<CharProperties>,
+        next: CharProperties,
+    ) -> (bool, State) {
         use GCBProperty::*;
 
         let next_state = self.next_state(next);

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,8 +15,8 @@ use crate::InCBProperty;
 /// of advanced text shaping anyway, so clusters over a certain length cannot be
 /// rendered anyway and so in that case we just want to find the beginning of
 /// the next cluster so we can know when to stop discarding overlong input.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum State {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum State {
     /// The initial state at the beginning of the text or when the following
     /// should be treated as if it were at the beginning of the text.
     Base,
@@ -45,6 +45,19 @@ pub enum State {
 }
 
 impl State {
+    /// Const-compatible `Eq`.
+    pub const fn eq(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Base, Self::Base)
+                | (Self::AwaitEmojiFlag, Self::AwaitEmojiFlag)
+                | (Self::GB11BeforeZWJ, Self::GB11BeforeZWJ)
+                | (Self::GB11AfterZWJ, Self::GB11AfterZWJ)
+                | (Self::GB9cConsonant, Self::GB9cConsonant)
+                | (Self::GB9cLinker, Self::GB9cLinker)
+        )
+    }
+
     /// Given the previous category and the next category, returns whether
     /// there is a grapheme cluster boundary between two characters of those
     /// categories in the current state, and the state that should be used for

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,15 +1,15 @@
-use super::*;
+use super::{ClusterAction, GraphemeMachine};
 
 // The tests in this file are only for the public-facing `GraphemeCluster`
 // API. The internal state machine implementation has its own tests under
 // `crate::state::tests`, where most of the interesting testing happens.
 
 use pretty_assertions::assert_eq;
+#[rustfmt::skip]
+use ::u8char::AsU8Chars;
 
 #[test]
 fn basics() {
-    use ::u8char::AsU8Chars;
-
     let mut clusters: Vec<String> = Vec::new();
     let mut current_cluster = String::new();
     let mut machine = GraphemeMachine::new();
@@ -50,8 +50,6 @@ fn basics() {
 
 #[test]
 fn end_of_input() {
-    use ::u8char::AsU8Chars;
-
     let mut machine = GraphemeMachine::new();
     let input = "Hello!\r\nBeep 🧑‍🌾";
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -89,3 +89,24 @@ fn next_chars_from_str() {
         ]
     );
 }
+#[test]
+const fn const_iter() {
+    const INPUT: &str = "Hello!\r\nBeep 🧑‍🌾";
+    const CHAR: char = const {
+        let mut machine = GraphemeMachine::new();
+        let mut iter = machine.next_chars_from_str(INPUT);
+
+        let mut c = '\0';
+        let mut i = 0;
+        while i < 9 {
+            i += 1;
+            if let Some((cluster, character)) = iter.next() {
+                if cluster.eq(ClusterAction::Split) {
+                    c = character;
+                }
+            }
+        }
+        c
+    };
+    assert![CHAR == 'B'];
+}


### PR DESCRIPTION
Thanks for making this! I was looking for a segmenting crate that could work in *const* contexts.

This PR makes all existing functionality *const* compatible. It also fixes making `u8char` public.

BTW It's a shame the LUT generator was lost. I may take a look at it, but it looks a tad complicated.